### PR TITLE
Add missing dependency

### DIFF
--- a/notebooks/3_Algorithms/2_Regression.livemd
+++ b/notebooks/3_Algorithms/2_Regression.livemd
@@ -2,7 +2,8 @@
 
 ```elixir
 Mix.install([
-  {:httpoison, "~> 1.8"}
+  {:httpoison, "~> 1.8"},
+  {:jason, "~> 1.3"}
 ])
 ```
 


### PR DESCRIPTION
Locally this  notebook errors without this since we call `Jason.decode`