### PR TITLE
Fix typos in notebooks

### DIFF
--- a/notebooks/1_MachineLearning/1_Intro.livemd
+++ b/notebooks/1_MachineLearning/1_Intro.livemd
@@ -167,7 +167,7 @@ Gibran.Tokeniser.tokenise(str)
 
 Gibran.Tokeniser.tokenise(str)
 |> Gibran.Counter.uniq_tokens()
-|> IO.inspect(label: "unqiue tokens")
+|> IO.inspect(label: "unique tokens")
 
 Gibran.Tokeniser.tokenise(str, exclude: &(String.length(&1) < 5))
 |> IO.inspect(label: "tokens > 10")
@@ -231,7 +231,7 @@ For example, the image below shows the error rate of a decision tree on both in-
 
 ### Underfitting
 
-Underfitting is when a model produces inaccurate prediction outcomes because it failed to catpure the complexity of the training data. It occurs when the model has not trained for enough time or the input variables are not significant enough to form a meaningful relationship between the input and output. Underfitting, like overfitting, generalizes poorly to out of sample data.
+Underfitting is when a model produces inaccurate prediction outcomes because it failed to capture the complexity of the training data. It occurs when the model has not trained for enough time or the input variables are not significant enough to form a meaningful relationship between the input and output. Underfitting, like overfitting, generalizes poorly to out of sample data.
 
 ![](images/underfit.png)
 

--- a/notebooks/1_MachineLearning/4_Reinforcement.livemd
+++ b/notebooks/1_MachineLearning/4_Reinforcement.livemd
@@ -54,11 +54,11 @@ Time for some Elixir
 
 <img src="https://static.thenounproject.com/png/1111032-200.png" alt="Brain icon" style="width: 85px; float: left; margin-bottom: 10px; margin-right: 20px;" />
 
-Take a break and explore an Elixir library called [Essense](https://github.com/nicbet/essence). It is a Natural Language Processing (NLP) and Text Summarization Library. NLP brings together the fields of linguistics and AI to explore how computers can understand text and spoken words like human beings can.
+Take a break and explore an Elixir library called [Essence](https://github.com/nicbet/essence). It is a Natural Language Processing (NLP) and Text Summarization Library. NLP brings together the fields of linguistics and AI to explore how computers can understand text and spoken words like human beings can.
 
 To make the most of this library we need a document. For ours we'll use [Req](https://github.com/wojtekmach/req) to get a short story from Project Gutenburg: The Yellow Wallpaper by Charlotte Perkins.
 
-Essense provides a convenience method for reading the plain text.
+Essence provides a convenience method for reading the plain text.
 
 ```elixir
 doc =

--- a/notebooks/2_Statistics/1_Intro.livemd
+++ b/notebooks/2_Statistics/1_Intro.livemd
@@ -29,7 +29,7 @@ After going over some machine learning algorithms we will take a brief detour in
 
 ## Statistical Learning
 
-We hear a lot about machine learning being the subject of "allowing computers to learn without being explicity programmed". But what does that mean? Broadly speaking, it means given one or more inputs we want to build a model that predicts, or estimates, an output. To correctly predict a model uses probability and statistics to infer patterns and relationships from data – collectively this is known as statistical learning which encompasses a vast array of tools for *understanding data*.
+We hear a lot about machine learning being the subject of "allowing computers to learn without being explicitly programmed". But what does that mean? Broadly speaking, it means given one or more inputs we want to build a model that predicts, or estimates, an output. To correctly predict a model uses probability and statistics to infer patterns and relationships from data – collectively this is known as statistical learning which encompasses a vast array of tools for *understanding data*.
 
 ### Examples
 
@@ -155,4 +155,4 @@ Further we can examine the mean and the standard deviation above and below the m
 
 <!-- livebook:{"break_markdown":true} -->
 
-Overall this is a suprising result - our strategy of always betting on black allows us, with some unlimited constraints, to always beat the house. Further, we typically reach our goal well within the 1000 spins that we've limited ourselves to. In fact we would be able to reach the same performance in under 250 spins.
+Overall this is a surprising result - our strategy of always betting on black allows us, with some unlimited constraints, to always beat the house. Further, we typically reach our goal well within the 1000 spins that we've limited ourselves to. In fact we would be able to reach the same performance in under 250 spins.

--- a/notebooks/3_Algorithms/3_Classification.livemd
+++ b/notebooks/3_Algorithms/3_Classification.livemd
@@ -47,7 +47,7 @@ Time for some Elixir
 
 [Paasaa](https://github.com/minibikini/paasaa) is Natural language detection for Elixir. To make the most of this library we need a few documents. Use [Req](https://github.com/wojtekmach/req) to get them from Project Gutenburg.
 
-Use the Essense library we explored in an earlier section to read the plain text.
+Use the Essence library we explored in an earlier section to read the plain text.
 
 ```elixir
 doc =

--- a/notebooks/8_NxInAction/YourOwn/1_Data.livemd
+++ b/notebooks/8_NxInAction/YourOwn/1_Data.livemd
@@ -22,7 +22,7 @@ Mix.install([
 
 ## Get ready
 
-Find a publically avilable dataset of your own like those on [Kaggle](https://www.kaggle.com/datasets) or [OpenML](https://www.openml.org/). Or, try this one we included with the training repo.
+Find a publicly available dataset of your own like those on [Kaggle](https://www.kaggle.com/datasets) or [OpenML](https://www.openml.org/). Or, try this one we included with the training repo.
 
 [Boston house-price data](http://lib.stat.cmu.edu/datasets/boston)
 

--- a/notebooks/9_WhatsNext/2_Future.livemd
+++ b/notebooks/9_WhatsNext/2_Future.livemd
@@ -46,7 +46,7 @@ y = Nx.tensor([1, 2, 4, 8, 9])
 Scholar.Metrics.Similarity.jaccard(x, y)
 ```
 
-As of a week ago, there is an approved PR waiting on a notebook to add the [K-Means aglorithm](https://github.com/elixir-nx/scholar/pull/21) to Scholar.
+As of a week ago, there is an approved PR waiting on a notebook to add the [K-Means algorithm](https://github.com/elixir-nx/scholar/pull/21) to Scholar.
 
 You don't have to wait to try it out. Simply scroll up to the Notebook dependencies and setup section. Comment out the first dep and uncomment the second to pull directly from the creators fork of Scholar. (Although it may be merged into the main Scholar repo by the time of training; you can try the code block out first.)
 

--- a/notebooks/glossary.livemd
+++ b/notebooks/glossary.livemd
@@ -216,7 +216,7 @@ pie showData
 
 <details>
   <summary>Regression</summary>
-  distinguishing data into continuous real values rather than clases or discrete values. Compared to classification, regression results in ordered continuous values by measuring the root mean square error.
+  distinguishing data into continuous real values rather than classes or discrete values. Compared to classification, regression results in ordered continuous values by measuring the root mean square error.
 </details>
 
 <!-- livebook:{"break_markdown":true} -->


### PR DESCRIPTION
Found via `codespell notebooks/ -L te,tre`